### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
 pignacio's scripts
 ==================
 
-.. image:: https://pypip.in/version/pignacio_scripts/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/pignacio_scripts.svg?style=flat
     :target: https://pypi.python.org/pypi/pignacio_scripts/
     :alt: Latest version
 
-.. image:: https://pypip.in/py_versions/pignacio_scripts/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/pignacio_scripts.svg?style=flat
     :target: https://pypi.python.org/pypi/pignacio_scripts/
     :alt: Supported Python versions
 
@@ -16,7 +16,7 @@ pignacio's scripts
 .. image:: https://coveralls.io/repos/pignacio/pignacio_scripts/badge.svg?branch=master
     :target: https://coveralls.io/r/pignacio/pignacio_scripts?branch=master
 
-.. image:: https://pypip.in/license/pignacio_scripts/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/pignacio_scripts.svg?style=flat
     :target: https://pypi.python.org/pypi/pignacio_scripts/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pignacio-scripts))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pignacio-scripts`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.